### PR TITLE
fix: audio download

### DIFF
--- a/main.py
+++ b/main.py
@@ -83,9 +83,11 @@ async def handle_url(update: Update, context: CallbackContext):
     url = update.message.text
     download_mode = "video"
     file_extention = ".mp4"
+    yt_dl_format = "bestvideo[ext=mp4][vcodec=avc1.4D401F]+bestaudio[ext=m4a]/best"
     if url.startswith('/audio '):
         download_mode = "audio"
         file_extention = ".mp3"
+        yt_dl_format = "bestaudio/best"
         messages_total.inc({"handler": "audio"})
         url = url[7:]
     else:
@@ -127,13 +129,13 @@ async def handle_url(update: Update, context: CallbackContext):
             asyncio.run_coroutine_threadsafe(progress_msg.edit_text(new_text), loop)
 
     def _get_info(url_: str) -> dict:
-        with yt_dlp.YoutubeDL({"quiet": True}) as ydl:
+        with yt_dlp.YoutubeDL({"quiet": True, "format": yt_dl_format}) as ydl:
             return ydl.extract_info(url_, download=False)
 
     def _download(url_: str):
         yt_dlp_options = {
             "outtmpl": filepath,
-            "format": "bestvideo[ext=mp4][vcodec=avc1.4D401F]+bestaudio[ext=m4a]/best",
+            "format": yt_dl_format,
             "postprocessors": [
                 {
                     "key": "FFmpegVideoConvertor",
@@ -145,7 +147,6 @@ async def handle_url(update: Update, context: CallbackContext):
             "quiet": True,
         }
         if download_mode == "audio":
-            yt_dlp_options["format"] = 'bestaudio/best'
             yt_dlp_options["postprocessors"] = [{
                 'key': 'FFmpegExtractAudio',
                 'preferredcodec': 'mp3',

--- a/main.py
+++ b/main.py
@@ -111,7 +111,7 @@ async def handle_url(update: Update, context: CallbackContext):
 
     prev_percent = 0
 
-    def _update_postprocessor(d):
+    def _update_filepath(d):
         nonlocal filepath
         if d["info_dict"]["filepath"]:
             filepath = d["info_dict"]["filepath"]
@@ -143,7 +143,7 @@ async def handle_url(update: Update, context: CallbackContext):
                 }
             ],
             "progress_hooks": [_update_progress_msg],
-            "postprocessor_hooks":[_update_postprocessor],
+            "postprocessor_hooks":[_update_filepath],
             "quiet": True,
         }
         if download_mode == "audio":

--- a/main.py
+++ b/main.py
@@ -109,6 +109,11 @@ async def handle_url(update: Update, context: CallbackContext):
 
     prev_percent = 0
 
+    def _update_postprocessor(d):
+        nonlocal filepath
+        if d["info_dict"]["filepath"]:
+            filepath = d["info_dict"]["filepath"]
+
     def _update_progress_msg(d):
         nonlocal prev_percent
         if d["status"] == "downloading":
@@ -136,6 +141,7 @@ async def handle_url(update: Update, context: CallbackContext):
                 }
             ],
             "progress_hooks": [_update_progress_msg],
+            "postprocessor_hooks":[_update_postprocessor],
             "quiet": True,
         }
         if download_mode == "audio":

--- a/main.py
+++ b/main.py
@@ -143,7 +143,7 @@ async def handle_url(update: Update, context: CallbackContext):
                 }
             ],
             "progress_hooks": [_update_progress_msg],
-            "postprocessor_hooks":[_update_filepath],
+            "postprocessor_hooks": [_update_filepath],
             "quiet": True,
         }
         if download_mode == "audio":


### PR DESCRIPTION
Two problems solved:
1. If postprocessor is used, `yt-dlp` may add a file extension one more time (e.g. `.mp3.mp3`), `postprocessor_hooks` is used to fix the problem
2. `format` is added to the `_get_info` function to extract audio size correctly